### PR TITLE
Fix PluginName typo

### DIFF
--- a/exclause/plugin_test.go
+++ b/exclause/plugin_test.go
@@ -1,0 +1,31 @@
+package exclause
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	extraClausePlugin "github.com/WinterYukky/gorm-extra-clause-plugin"
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+func Test(t *testing.T) {
+	mockDB, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer mockDB.Close()
+	db, _ := gorm.Open(mysql.New(mysql.Config{
+		Conn:                      mockDB,
+		SkipInitializeWithVersion: true,
+	}))
+	err = db.Use(extraClausePlugin.New())
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when registering the plugin", err)
+	}
+
+	_, ok := db.Plugins["ExtraClausePlugin"]
+	if !ok {
+		t.Errorf("Could not find ExtraClausePlugin after registration")
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -7,7 +7,7 @@ type ExtraClausePlugin struct{}
 
 // Name return plugin name
 func (e *ExtraClausePlugin) Name() string {
-	return "ExtraCalusePlugin"
+	return "ExtraClausePlugin"
 }
 
 // Initialize register BuildClauses


### PR DESCRIPTION
The Name() function has a typo, this causes the key in the Gorm db.Plugins map to be incorrect.

See https://github.com/WinterYukky/gorm-extra-clause-plugin/issues/62