### PR TITLE
Support UPDATE queries

### DIFF
--- a/exclause/with_test.go
+++ b/exclause/with_test.go
@@ -79,6 +79,74 @@ func TestWith_Query(t *testing.T) {
 	}
 }
 
+func TestWith_Update(t *testing.T) {
+	tests := []struct {
+		name      string
+		operation func(db *gorm.DB) *gorm.DB
+		want      string
+		wantArgs  []driver.Value
+	}{
+		{
+			name: "When Subquery is clause.Expr, then should be used as subquery",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Subquery: clause.Expr{SQL: "SELECT * FROM `users` WHERE `name` = ?", Vars: []interface{}{"WinterYukky"}}}}}).Table("users").Where("`users`.`id` IN (SELECT `id` FROM `cte`)").Update("name", "new_name")
+			},
+			want:     "WITH `cte` AS (SELECT * FROM `users` WHERE `name` = ?) UPDATE `users` SET `name`=? WHERE `users`.`id` IN (SELECT `id` FROM `cte`)",
+			wantArgs: []driver.Value{"WinterYukky", "new_name"},
+		},
+		{
+			name: "When Subquery is exclause.Subquery, then should be used as subquery",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Subquery: Subquery{DB: db.Table("users").Where("`name` = ?", "WinterYukky")}}}}).Table("users").Where("`users`.`id` IN (SELECT `id` FROM `cte`)").Update("name", "new_name")
+			},
+			want:     "WITH `cte` AS (SELECT * FROM `users` WHERE `name` = ?) UPDATE `users` SET `name`=? WHERE `users`.`id` IN (SELECT `id` FROM `cte`)",
+			wantArgs: []driver.Value{"WinterYukky", "new_name"},
+		},
+		{
+			name: "When has specific fields, then should be used with columns specified",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.Clauses(With{CTEs: []CTE{{Name: "cte", Columns: []string{"id", "name"}, Subquery: Subquery{DB: db.Table("users")}}}}).Table("users").Where("`users`.`id` IN (SELECT `id` FROM `cte`)").Update("name", "new_name")
+			},
+			want:     "WITH `cte` (`id`,`name`) AS (SELECT * FROM `users`) UPDATE `users` SET `name`=? WHERE `users`.`id` IN (SELECT `id` FROM `cte`)",
+			wantArgs: []driver.Value{"new_name"},
+		},
+		{
+			name: "When contains recursive even once, then should be used RECURSIVE keyword",
+			operation: func(db *gorm.DB) *gorm.DB {
+				return db.
+					Clauses(With{Recursive: true, CTEs: []CTE{{Name: "cte1", Subquery: Subquery{DB: db.Table("users")}}}}).
+					Clauses(With{Recursive: false, CTEs: []CTE{{Name: "cte2", Subquery: Subquery{DB: db.Table("users")}}}}).
+					Table("users").Where("`users`.`id` IN (SELECT `id` FROM `cte`)").Update("name", "new_name")
+			},
+			want:     "WITH RECURSIVE `cte1` AS (SELECT * FROM `users`),`cte2` AS (SELECT * FROM `users`) UPDATE `users` SET `name`=? WHERE `users`.`id` IN (SELECT `id` FROM `cte`)",
+			wantArgs: []driver.Value{"new_name"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockDB, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+			}
+			defer mockDB.Close()
+			db, _ := gorm.Open(mysql.New(mysql.Config{
+				Conn:                      mockDB,
+				SkipInitializeWithVersion: true,
+			}))
+			db.Use(extraClausePlugin.New())
+			mock.ExpectBegin()
+			mock.ExpectExec(regexp.QuoteMeta(tt.want)).WithArgs(tt.wantArgs...).WillReturnResult(sqlmock.NewResult(0, 1))
+			mock.ExpectCommit()
+			if tt.operation != nil {
+				db = tt.operation(db)
+			}
+			if db.Error != nil {
+				t.Errorf(db.Error.Error())
+			}
+		})
+	}
+}
+
 func TestNewWith(t *testing.T) {
 	mockDB, _, err := sqlmock.New()
 	if err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -13,10 +13,13 @@ func (e *ExtraClausePlugin) Name() string {
 // Initialize register BuildClauses
 func (e *ExtraClausePlugin) Initialize(db *gorm.DB) error {
 	db.Callback().Query().Clauses = []string{
-		"WITH", "SELECT", "UPDATE", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
 	db.Callback().Row().Clauses = []string{
-		"WITH", "SELECT", "UPDATE", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+	}
+	db.Callback().Query().Clauses = []string{
+		"WITH", "UPDATE", "SET", "FROM", "WHERE", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
 	return nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -18,7 +18,7 @@ func (e *ExtraClausePlugin) Initialize(db *gorm.DB) error {
 	db.Callback().Row().Clauses = []string{
 		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
-	db.Callback().Query().Clauses = []string{
+	db.Callback().Update().Clauses = []string{
 		"WITH", "UPDATE", "SET", "FROM", "WHERE", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
 	return nil

--- a/plugin.go
+++ b/plugin.go
@@ -13,10 +13,10 @@ func (e *ExtraClausePlugin) Name() string {
 // Initialize register BuildClauses
 func (e *ExtraClausePlugin) Initialize(db *gorm.DB) error {
 	db.Callback().Query().Clauses = []string{
-		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+		"WITH", "SELECT", "UPDATE", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
 	db.Callback().Row().Clauses = []string{
-		"WITH", "SELECT", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
+		"WITH", "SELECT", "UPDATE", "FROM", "WHERE", "GROUP BY", "UNION", "INTERSECT", "EXCEPT", "ORDER BY", "LIMIT", "FOR",
 	}
 	return nil
 }


### PR DESCRIPTION
This adds support for UPDATE queries.

Note that for whatever reason, `gorm` doesn't support joins in `Update` or `Updates` calls, but we can do `WHERE x IN (SELECT ...)` to get around it for now.  In either case, that's not a problem for this plugin.